### PR TITLE
deleted flow builder

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -281,14 +281,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  flow_builder:
-    dependency: "direct main"
-    description:
-      name: flow_builder
-      sha256: "9e66aa7209e9a31c347bb316abf191d2300db41cd6b7254f89abd4e76d9b3f8d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   get_it: ^8.0.0
   flutter_svg: ^2.0.10+1
   google_sign_in: ^6.2.1
-  flow_builder: ^0.1.0
   http: ^1.2.2
   flutter_staggered_grid_view: ^0.7.0
   cached_network_image: ^3.3.1


### PR DESCRIPTION
### Removal of `flow_builder`

- **Description**: The `flow_builder` package was removed as it is no longer needed in the project.
- **Reason**: The functionality provided by `flow_builder` is no longer required, simplifying the project's dependencies.