### PR TITLE
Refactor: Use const constructors for stateless widgets and improve

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -49,6 +49,9 @@ linter:
     # This rule enforces the use of super when overriding members.
     use_super_parameters: true
 
+    prefer_const_constructors: true
+    prefer_const_literals_to_create_immutables: true
+
 analyzer:
   exclude:
     - lib/src/core/localization/*.dart

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,9 +28,9 @@ Future<void> main() async {
     DeviceOrientation.portraitDown,
   ]);
   SystemChrome.setSystemUIOverlayStyle(
-    SystemUiOverlayStyle(
+    const SystemUiOverlayStyle(
       systemNavigationBarColor: Colors.transparent,
     ),
   );
-  runApp(App());
+  runApp(const App());
 }

--- a/lib/src/core/constants/constants.dart
+++ b/lib/src/core/constants/constants.dart
@@ -69,7 +69,7 @@ class Constants {
   static PageTransitionsTheme pageTransition = PageTransitionsTheme(
     builders: Map<TargetPlatform, PageTransitionsBuilder>.fromIterable(
       TargetPlatform.values,
-      value: (_) => FadeForwardsPageTransitionsBuilder(),
+      value: (_) => const FadeForwardsPageTransitionsBuilder(),
     ),
   );
 }

--- a/lib/src/core/functions/custom_snack_bar.dart
+++ b/lib/src/core/functions/custom_snack_bar.dart
@@ -13,7 +13,7 @@ void showCustomSnackbar(
       SnackBar(
         content: Text(
           message.capitalize(),
-          style: TextStyle(
+          style: const TextStyle(
             fontWeight: FontWeight.w700,
           ),
         ),

--- a/lib/src/core/router/app_router.dart
+++ b/lib/src/core/router/app_router.dart
@@ -52,11 +52,12 @@ class AppRouter {
       // Rutas sin NavigationBar
       GoRoute(
         path: '/',
-        builder: (BuildContext context, GoRouterState state) => LoadingPage(),
+        builder: (BuildContext context, GoRouterState state) =>
+            const LoadingPage(),
       ),
       GoRoute(
         path: '/login',
-        builder: (BuildContext context, GoRouterState state) => Login(),
+        builder: (BuildContext context, GoRouterState state) => const Login(),
       ),
 
       //Cambiar por statefullshellroute
@@ -64,7 +65,7 @@ class AppRouter {
         builder: (BuildContext context, GoRouterState state, Widget child) {
           return Scaffold(
             body: child,
-            bottomNavigationBar: AppNavigationBar(),
+            bottomNavigationBar: const AppNavigationBar(),
           );
         },
         routes: <RouteBase>[
@@ -72,7 +73,7 @@ class AppRouter {
             path: '/home',
             name: 'home',
             pageBuilder: (BuildContext context, GoRouterState state) =>
-                NoTransitionPage<Home>(
+                const NoTransitionPage<Home>(
               child: Home(),
             ),
           ),
@@ -80,21 +81,21 @@ class AppRouter {
             path: '/favorites',
             name: 'favorites',
             pageBuilder: (BuildContext context, GoRouterState state) =>
-                NoTransitionPage<Favorites>(
+                const NoTransitionPage<Favorites>(
               child: Favorites(),
             ),
           ),
           GoRoute(
             path: '/searchpage',
             pageBuilder: (BuildContext context, GoRouterState state) =>
-                NoTransitionPage<SearchPage>(
+                const NoTransitionPage<SearchPage>(
               child: SearchPage(),
             ),
           ),
           GoRoute(
             path: '/usermenu',
             pageBuilder: (BuildContext context, GoRouterState state) =>
-                NoTransitionPage<UserMenu>(
+                const NoTransitionPage<UserMenu>(
               child: UserMenu(),
             ),
           )
@@ -122,14 +123,15 @@ class AppRouter {
             path: 'purchase',
             name: 'purchase',
             builder: (BuildContext context, GoRouterState state) {
-              return Purchase();
+              return const Purchase();
             },
           ),
         ],
       ),
       GoRoute(
         path: '/mypurchases',
-        builder: (BuildContext context, GoRouterState state) => MyPurchases(),
+        builder: (BuildContext context, GoRouterState state) =>
+            const MyPurchases(),
       ),
       GoRoute(
         path: '/fullScrenImage',
@@ -157,18 +159,20 @@ class AppRouter {
       ),
       GoRoute(
         path: '/mylocations',
-        builder: (BuildContext context, GoRouterState state) => MyLocations(),
+        builder: (BuildContext context, GoRouterState state) =>
+            const MyLocations(),
       ),
       GoRoute(
         path: '/settings',
         name: 'settings',
-        builder: (BuildContext context, GoRouterState state) => Settings(),
+        builder: (BuildContext context, GoRouterState state) =>
+            const Settings(),
         routes: <RouteBase>[
           GoRoute(
             path: 'languages',
             name: 'language page',
             builder: (BuildContext context, GoRouterState state) {
-              return LanguagePage();
+              return const LanguagePage();
             },
           ),
         ],
@@ -176,7 +180,7 @@ class AppRouter {
       GoRoute(
         path: '/profile',
         name: 'user account',
-        builder: (BuildContext context, GoRouterState state) => Profile(),
+        builder: (BuildContext context, GoRouterState state) => const Profile(),
       )
     ],
   );

--- a/lib/src/core/theme/app_dark_theme.dart
+++ b/lib/src/core/theme/app_dark_theme.dart
@@ -28,7 +28,7 @@ class AppDarkTheme {
         backgroundColor: ThemeData.dark().scaffoldBackgroundColor,
         surfaceTintColor: ThemeData.dark().scaffoldBackgroundColor,
       ),
-      progressIndicatorTheme: ProgressIndicatorThemeData(
+      progressIndicatorTheme: const ProgressIndicatorThemeData(
         // ignore: deprecated_member_use
         year2023: false,
         color: Constants.primaryColor,

--- a/lib/src/core/theme/app_light_theme.dart
+++ b/lib/src/core/theme/app_light_theme.dart
@@ -20,7 +20,7 @@ class AppLightTheme {
       pageTransitionsTheme: Constants.pageTransition,
       colorSchemeSeed: Constants.primaryColor,
       fontFamily: 'Questrial',
-      progressIndicatorTheme: ProgressIndicatorThemeData(
+      progressIndicatorTheme: const ProgressIndicatorThemeData(
         // ignore: deprecated_member_use
         year2023: false,
         color: Constants.primaryColor,
@@ -64,7 +64,7 @@ class AppLightTheme {
         border: OutlineInputBorder(
           borderRadius: Constants.mainBorderRadius,
           gapPadding: Constants.mainPaddingValue * 2,
-          borderSide: BorderSide(
+          borderSide: const BorderSide(
             width: 0,
             style: BorderStyle.none,
           ),

--- a/lib/src/features/auth/presentation/login/login.dart
+++ b/lib/src/features/auth/presentation/login/login.dart
@@ -81,10 +81,10 @@ class _LoginState extends State<Login> {
         builder: (BuildContext context, LoginState state) {
           return Scaffold(
             body: DecoratedBox(
-              decoration: BoxDecoration(
+              decoration: const BoxDecoration(
                 gradient: LinearGradient(
                   begin: Alignment.topCenter,
-                  stops: const <double>[.54, 1],
+                  stops: <double>[.54, 1],
                   end: Alignment.bottomCenter,
                   colors: <Color>[
                     Constants.primaryColor,
@@ -202,7 +202,7 @@ class _LoginState extends State<Login> {
                                 AppLocalizations.of(context)!
                                     .newUser
                                     .capitalize(),
-                                style: TextStyle(
+                                style: const TextStyle(
                                   fontFamily: 'RedHat',
                                   color: Constants.primaryColor,
                                   fontSize: 16,

--- a/lib/src/features/auth/presentation/login/widgets/auth_btn.dart
+++ b/lib/src/features/auth/presentation/login/widgets/auth_btn.dart
@@ -51,7 +51,7 @@ class AuthBtn extends StatelessWidget {
                     true => const CupertinoActivityIndicator(),
                     false => Text(
                         _label.capitalize(),
-                        style: TextStyle(
+                        style: const TextStyle(
                           color: Constants.primaryColor,
                           fontFamily: 'RedHat',
                           fontWeight: FontWeight.bold,

--- a/lib/src/features/auth/presentation/signup/signup.dart
+++ b/lib/src/features/auth/presentation/signup/signup.dart
@@ -54,10 +54,10 @@ class _SignUpState extends State<SignUp> {
       create: (BuildContext context) => sl<SignupCubit>(),
       child: Scaffold(
         body: DecoratedBox(
-          decoration: BoxDecoration(
+          decoration: const BoxDecoration(
             gradient: LinearGradient(
               begin: Alignment.topCenter,
-              stops: const <double>[.54, 1],
+              stops: <double>[.54, 1],
               end: Alignment.bottomCenter,
               colors: <Color>[
                 Constants.primaryColor,
@@ -207,7 +207,7 @@ class _SignUpState extends State<SignUp> {
                                   AppLocalizations.of(context)!
                                       .haveAccount
                                       .capitalize(),
-                                  style: TextStyle(
+                                  style: const TextStyle(
                                     fontFamily: 'RedHat',
                                     color: Constants.primaryColor,
                                     fontSize: 16,

--- a/lib/src/features/current_location_button/presentation/cubit/current_location_button_cubit.dart
+++ b/lib/src/features/current_location_button/presentation/cubit/current_location_button_cubit.dart
@@ -11,7 +11,7 @@ class CurrentLocationButtonCubit extends Cubit<CurrentLocationButtonState> {
   CurrentLocationButtonCubit({
     required CurrentLocationUsecase usecase,
   })  : _usecase = usecase,
-        super(CurrentLocationButtonState()) {
+        super(const CurrentLocationButtonState()) {
     _getCurrentDefaultLocation();
   }
   final CurrentLocationUsecase _usecase;

--- a/lib/src/features/current_location_button/presentation/current_location_button.dart
+++ b/lib/src/features/current_location_button/presentation/current_location_button.dart
@@ -38,7 +38,7 @@ class _CurrentLocationButtonState extends State<CurrentLocationButton> {
                       spacing: Constants.mainPaddingValue / 2,
                       mainAxisSize: MainAxisSize.min,
                       children: <Widget>[
-                        Icon(
+                        const Icon(
                           HugeIcons.strokeRoundedLocation05,
                         ),
                         Flexible(
@@ -48,18 +48,18 @@ class _CurrentLocationButtonState extends State<CurrentLocationButton> {
                                     : '${state.locationEntity.address}(${state.locationEntity.name.trim()})')
                                 .toTitleCase(),
                             maxLines: 1,
-                            style: TextStyle(
+                            style: const TextStyle(
                               fontWeight: FontWeight.w700,
                             ),
                           ),
                         ),
                       ],
                     ),
-                  Loading _ => Center(
+                  Loading _ => const Center(
                       child: CircularProgressIndicator(),
                     ),
                   Error _ => Text(state.message),
-                  _ => SizedBox.shrink()
+                  _ => const SizedBox.shrink()
                 },
               ),
             ),

--- a/lib/src/features/favorites/presentation/cubit/favorites_cubit.dart
+++ b/lib/src/features/favorites/presentation/cubit/favorites_cubit.dart
@@ -10,7 +10,7 @@ class FavoritesCubit extends Cubit<FavoritesState> {
   FavoritesCubit({
     required FavoritesUsecase usecase,
   })  : _usecase = usecase,
-        super(FavoritesState());
+        super(const FavoritesState());
   final FavoritesUsecase _usecase;
   Future<void> getUserFavorites() async {
     try {

--- a/lib/src/features/favorites/presentation/favorites.dart
+++ b/lib/src/features/favorites/presentation/favorites.dart
@@ -45,7 +45,7 @@ class _FavoritesState extends State<Favorites> {
                 SliverToBoxAdapter(
                   child: SwitchTransition(
                     child: switch (state.favoriteStatus) {
-                      FavoriteStatus.loading => LoadingStatus(),
+                      FavoriteStatus.loading => const LoadingStatus(),
                       FavoriteStatus.error => Center(
                           child: Text(state.message),
                         ),
@@ -57,7 +57,7 @@ class _FavoritesState extends State<Favorites> {
                                 .deleteFavoriteProduct(productId: productId);
                           },
                         ),
-                      FavoriteStatus.waiting => SizedBox.shrink(),
+                      FavoriteStatus.waiting => const SizedBox.shrink(),
                     },
                   ),
                 ),

--- a/lib/src/features/favorites/presentation/widgets/favorite_header.dart
+++ b/lib/src/features/favorites/presentation/widgets/favorite_header.dart
@@ -19,7 +19,7 @@ class FavoriteHeader extends SliverPersistentHeaderDelegate {
             child: ClipRRect(
               child: BackdropFilter(
                 filter: Constants.imageFilterBlur,
-                child: DecoratedBox(
+                child: const DecoratedBox(
                   decoration: BoxDecoration(
                     color: Constants.secondaryColor,
                   ),
@@ -42,7 +42,7 @@ class FavoriteHeader extends SliverPersistentHeaderDelegate {
                   ),
                   Text('tus favoritos'.capitalize(),
                       style: Constants.titleStyle),
-                  SizedBox(
+                  const SizedBox(
                     width: 50,
                   )
                 ],

--- a/lib/src/features/favorites/presentation/widgets/favorite_product_tile.dart
+++ b/lib/src/features/favorites/presentation/widgets/favorite_product_tile.dart
@@ -27,8 +27,8 @@ class FavoriteProductTile extends StatelessWidget {
         background: Container(
           color: Colors.red, // Color de fondo al deslizar
           alignment: Alignment.centerRight,
-          padding: EdgeInsets.symmetric(horizontal: 20),
-          child: Icon(Icons.delete, color: Colors.white),
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: const Icon(Icons.delete, color: Colors.white),
         ),
         child: Material(
           color: Colors.transparent,
@@ -78,14 +78,14 @@ class FavoriteProductTile extends StatelessWidget {
                                   _favorite.name.capitalize(),
                                   maxLines: 3,
                                   overflow: TextOverflow.ellipsis,
-                                  style: TextStyle(
+                                  style: const TextStyle(
                                     fontWeight: FontWeight.w800,
                                   ),
                                 ),
                               ),
                               Text(
                                 formatPrice(_favorite.basePrice),
-                                style: TextStyle(
+                                style: const TextStyle(
                                     fontSize: 18,
                                     color: Constants.primaryColor,
                                     fontWeight: FontWeight.w900),

--- a/lib/src/features/financial_information/presentation/cubit/financial_information_cubit.dart
+++ b/lib/src/features/financial_information/presentation/cubit/financial_information_cubit.dart
@@ -18,7 +18,7 @@ class FinancialInformationCubit extends Cubit<FinancialInformationState> {
       );
       emit(Success(product: response));
     } catch (e) {
-      emit(Error());
+      emit(const Error());
     }
   }
 }

--- a/lib/src/features/financial_information/presentation/financial_information.dart
+++ b/lib/src/features/financial_information/presentation/financial_information.dart
@@ -71,7 +71,7 @@ class _FinancialInformationState extends State<FinancialInformation> {
                   child: Column(
                     spacing: Constants.mainPaddingValue,
                     mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
+                    children: const <Widget>[
                       Text(
                         'Obteniendo datos de compra',
                         style: TextStyle(

--- a/lib/src/features/home/presentation/cubit/home_cubit.dart
+++ b/lib/src/features/home/presentation/cubit/home_cubit.dart
@@ -9,7 +9,7 @@ class HomeCubit extends Cubit<HomeState> {
   HomeCubit({
     required HomeDataUsecase usecase,
   })  : _usecase = usecase,
-        super(HomeState());
+        super(const HomeState());
 
   final HomeDataUsecase _usecase;
 

--- a/lib/src/features/home/presentation/home.dart
+++ b/lib/src/features/home/presentation/home.dart
@@ -32,11 +32,11 @@ class _HomeState extends State<Home> with AutomaticKeepAliveClientMixin {
             child: CustomScrollView(
               physics: Constants.bouncingScrollPhysics,
               slivers: <Widget>[
-                HomeSliverAppBar(),
+                const HomeSliverAppBar(),
                 WellcomeMessage(),
                 if (state is LoadingHomeData)
-                  SliverFillRemaining(
-                    child: const LoadingStatus(),
+                  const SliverFillRemaining(
+                    child: LoadingStatus(),
                   ),
                 if (state is ErrorGettingHomeData)
                   SliverFillRemaining(
@@ -48,7 +48,7 @@ class _HomeState extends State<Home> with AutomaticKeepAliveClientMixin {
                   SliverList(
                     delegate: SliverChildListDelegate.fixed(
                       <Widget>[
-                        PromotionsAndDiscounts(),
+                        const PromotionsAndDiscounts(),
                         SizedBox(
                           height: Constants.mainPaddingValue,
                         ),

--- a/lib/src/features/home/presentation/widgets/header/header.dart
+++ b/lib/src/features/home/presentation/widgets/header/header.dart
@@ -14,7 +14,7 @@ class HomeSliverAppBar extends StatelessWidget {
       snap: true,
       elevation: 0,
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-      actions: <Widget>[
+      actions: const <Widget>[
         SafeArea(
           child: HeaderButton(
             icon: HugeIcons.strokeRoundedNotification01,

--- a/lib/src/features/home/presentation/widgets/lastseen/lastseen.dart
+++ b/lib/src/features/home/presentation/widgets/lastseen/lastseen.dart
@@ -18,7 +18,7 @@ class LastSeen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (lastSeenProducts.isEmpty) {
-      return SizedBox.shrink();
+      return const SizedBox.shrink();
     }
     return Padding(
       padding: Constants.mainPadding,
@@ -35,7 +35,7 @@ class LastSeen extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              Text(
+              const Text(
                 'Visto anteriormente',
                 style: TextStyle(
                   fontSize: 18,
@@ -45,7 +45,7 @@ class LastSeen extends StatelessWidget {
               GridView.builder(
                 shrinkWrap: true,
                 padding: EdgeInsets.only(top: Constants.mainPaddingValue / 2),
-                physics: NeverScrollableScrollPhysics(),
+                physics: const NeverScrollableScrollPhysics(),
                 gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                   crossAxisCount: 2,
                   crossAxisSpacing: Constants.mainPaddingValue,
@@ -113,7 +113,7 @@ class LastSeen extends StatelessWidget {
                             ),
                             Text(
                               lastSeenProducts[index].name.capitalize(),
-                              style: TextStyle(
+                              style: const TextStyle(
                                   fontWeight: FontWeight.w800,
                                   fontSize: 15,
                                   height: 1),
@@ -121,7 +121,7 @@ class LastSeen extends StatelessWidget {
                             Flexible(
                               child: Text(
                                 formatPrice(lastSeenProducts[index].basePrice),
-                                style: TextStyle(
+                                style: const TextStyle(
                                     color: Constants.primaryColor,
                                     fontWeight: FontWeight.w700),
                               ),

--- a/lib/src/features/home/presentation/widgets/products/products.dart
+++ b/lib/src/features/home/presentation/widgets/products/products.dart
@@ -33,14 +33,14 @@ class _ProductsState extends State<Products> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 spacing: Constants.mainPaddingValue,
                 children: <Widget>[
-                  Icon(
+                  const Icon(
                     Icons.inbox,
                     color: Constants.secondaryColor,
                     size: 60,
                   ),
                   Text(
                     'no hay productos disponibles'.capitalize(),
-                    style: TextStyle(
+                    style: const TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.bold,
                     ),

--- a/lib/src/features/home/presentation/widgets/products/widgets/favorite/add_favorite.dart
+++ b/lib/src/features/home/presentation/widgets/products/widgets/favorite/add_favorite.dart
@@ -30,7 +30,7 @@ class AddToFavoriteButton extends StatelessWidget {
               child: ClipRRect(
                 child: BackdropFilter(
                   filter: Constants.imageFilterBlur,
-                  child: DecoratedBox(
+                  child: const DecoratedBox(
                     decoration: BoxDecoration(
                       color: Constants.secondaryColor,
                     ),

--- a/lib/src/features/home/presentation/widgets/products/widgets/favorite/cubit/add_favorite_cubit.dart
+++ b/lib/src/features/home/presentation/widgets/products/widgets/favorite/cubit/add_favorite_cubit.dart
@@ -9,7 +9,7 @@ class AddToFavoriteCubit extends Cubit<AddFavoriteState> {
   AddToFavoriteCubit({
     required FavoritesUsecase usecase,
   })  : _usecase = usecase,
-        super(AddFavoriteState());
+        super(const AddFavoriteState());
 
   final FavoritesUsecase _usecase;
 

--- a/lib/src/features/home/presentation/widgets/promotions/promotions.dart
+++ b/lib/src/features/home/presentation/widgets/promotions/promotions.dart
@@ -42,7 +42,7 @@ class _PromotionsAndDiscountsState extends State<PromotionsAndDiscounts> {
         shape: RoundedRectangleBorder(
           borderRadius: Constants.mainBorderRadius,
         ),
-        flexWeights: <int>[1, 10, 1],
+        flexWeights: const <int>[1, 10, 1],
         children: ImageInfo.values.map((ImageInfo image) {
           return HeroLayoutCard(imageInfo: image);
         }).toList(),

--- a/lib/src/features/home/presentation/widgets/sellers/sellers.dart
+++ b/lib/src/features/home/presentation/widgets/sellers/sellers.dart
@@ -66,7 +66,7 @@ class _SellersListState extends State<SellersList> {
                         widget.sellers[index].name,
                         maxLines: 2,
                         textAlign: TextAlign.center,
-                        style: TextStyle(
+                        style: const TextStyle(
                           height: .9,
                           fontWeight: FontWeight.w800,
                           fontSize: 16,

--- a/lib/src/features/language_page/widgets/languaje_button.dart
+++ b/lib/src/features/language_page/widgets/languaje_button.dart
@@ -32,15 +32,15 @@ class _LanguageButtonState extends State<LanguageButton> {
             Text(
               'cambiar idioma'.capitalize(),
             ),
-            Spacer(),
+            const Spacer(),
             Text(
               '( ${_appCubit.state.locale.languageCode} )',
-              style: TextStyle(
+              style: const TextStyle(
                 fontWeight: FontWeight.w600,
                 color: Colors.grey,
               ),
             ),
-            Icon(
+            const Icon(
               Icons.arrow_forward_ios_rounded,
               size: 16,
             )

--- a/lib/src/features/loading/loading.dart
+++ b/lib/src/features/loading/loading.dart
@@ -9,7 +9,7 @@ class LoadingPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return const Scaffold(
       body: LoadingStatus(),
     );
   }

--- a/lib/src/features/my_locations/domain/entity/my_locations_entity.dart
+++ b/lib/src/features/my_locations/domain/entity/my_locations_entity.dart
@@ -59,7 +59,7 @@ class MyLocationsEntity extends Equatable {
     address: '',
     name: '',
     description: '',
-    position: LatLng(0, 0),
+    position: const LatLng(0, 0),
     distric: '',
     mapImage: Uint8List.fromList(<int>[]),
     isDefault: false,

--- a/lib/src/features/my_locations/presentation/cubit/my_locations_cubit.dart
+++ b/lib/src/features/my_locations/presentation/cubit/my_locations_cubit.dart
@@ -11,7 +11,7 @@ class MyLocationsCubit extends Cubit<MyLocationsState> {
   MyLocationsCubit({
     required MyLocationsUsecase usecase,
   })  : _usecase = usecase,
-        super(MyLocationsState()) {
+        super(const MyLocationsState()) {
     getLocations();
   }
 

--- a/lib/src/features/my_locations/presentation/my_locations.dart
+++ b/lib/src/features/my_locations/presentation/my_locations.dart
@@ -37,17 +37,17 @@ class _MyLocationsState extends State<MyLocations> {
                   centerTitle: true,
                   leading: InkWell(
                     onTap: () => context.pop(),
-                    child: Icon(Icons.arrow_back_ios_new_rounded),
+                    child: const Icon(Icons.arrow_back_ios_new_rounded),
                   ),
                   title: Text(
                     'ubicaciones'.capitalize(),
-                    style: TextStyle(
+                    style: const TextStyle(
                       fontSize: 16,
                     ),
                   ),
                 ),
                 if (state is Loading)
-                  SliverFillRemaining(
+                  const SliverFillRemaining(
                     fillOverscroll: true,
                     hasScrollBody: false,
                     child: Center(
@@ -81,7 +81,7 @@ class _LocationsBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (locations.isEmpty) {
-      return EmptyLocations();
+      return const EmptyLocations();
     }
 
     return SliverPadding(
@@ -91,7 +91,7 @@ class _LocationsBody extends StatelessWidget {
           <Widget>[
             Padding(
               padding: Constants.mainPaddingSymetricVertical,
-              child: Text(
+              child: const Text(
                 'Selecciona la ubicacion de entrega de tus pedidos',
                 style: TextStyle(
                   fontSize: 16,
@@ -107,7 +107,7 @@ class _LocationsBody extends StatelessWidget {
             ),
             Padding(
               padding: Constants.paddingTop,
-              child: AddLocation(),
+              child: const AddLocation(),
             )
           ],
         ),

--- a/lib/src/features/my_locations/presentation/widgets/add_location.dart
+++ b/lib/src/features/my_locations/presentation/widgets/add_location.dart
@@ -37,7 +37,7 @@ class AddLocation extends StatelessWidget {
               duration: Constants.animationTransition,
             ),
             builder: (BuildContext context) {
-              return NewLocation();
+              return const NewLocation();
             },
           );
         },
@@ -47,7 +47,7 @@ class AddLocation extends StatelessWidget {
             spacing: 16,
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
-              Icon(
+              const Icon(
                 HugeIcons.strokeRoundedLocationAdd02,
               ),
               Text(

--- a/lib/src/features/my_locations/presentation/widgets/empty_locations.dart
+++ b/lib/src/features/my_locations/presentation/widgets/empty_locations.dart
@@ -11,7 +11,7 @@ class EmptyLocations extends StatelessWidget {
     return SliverFillRemaining(
       hasScrollBody: false,
       child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 50),
+        padding: const EdgeInsets.symmetric(horizontal: 50),
         child: Center(
           child: Material(
             borderRadius: Constants.mainBorderRadius,
@@ -27,12 +27,12 @@ class EmptyLocations extends StatelessWidget {
                   Text(
                     'aun no tienes ubicaciones registradas'.capitalize(),
                     textAlign: TextAlign.center,
-                    style: TextStyle(
+                    style: const TextStyle(
                       fontWeight: FontWeight.w700,
                       fontSize: 16,
                     ),
                   ),
-                  AddLocation()
+                  const AddLocation()
                 ],
               ),
             ),

--- a/lib/src/features/my_locations/presentation/widgets/location_tile.dart
+++ b/lib/src/features/my_locations/presentation/widgets/location_tile.dart
@@ -64,7 +64,7 @@ class _LocationTileState extends State<LocationTile>
         decoration: BoxDecoration(
           color: Colors.grey.shade300,
           borderRadius: Constants.mainBorderRadius,
-          boxShadow: <BoxShadow>[
+          boxShadow: const <BoxShadow>[
             BoxShadow(
               color: Color.fromRGBO(0, 0, 0, 0.1),
               offset: Offset(0, 10),
@@ -140,13 +140,13 @@ class _LocationTileState extends State<LocationTile>
       child: Text.rich(
         TextSpan(
           text: '$label: '.capitalize(),
-          style: TextStyle(
+          style: const TextStyle(
             fontWeight: FontWeight.bold,
           ),
           children: <InlineSpan>[
             TextSpan(
               text: data.capitalize(),
-              style: TextStyle(
+              style: const TextStyle(
                 fontWeight: FontWeight.w300,
               ),
             ),

--- a/lib/src/features/my_purchases/presentation/mypurchases.dart
+++ b/lib/src/features/my_purchases/presentation/mypurchases.dart
@@ -32,7 +32,7 @@ class _MyPurchasesState extends State<MyPurchases> {
                   pinned: true,
                 ),
                 if (state is Loading)
-                  SliverFillRemaining(
+                  const SliverFillRemaining(
                     child: Center(
                       child: CircularProgressIndicator(),
                     ),

--- a/lib/src/features/my_purchases/presentation/widgets/empty_purchases.dart
+++ b/lib/src/features/my_purchases/presentation/widgets/empty_purchases.dart
@@ -22,15 +22,15 @@ class EmptyPurchases extends StatelessWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: <Widget>[
-                Icon(
+                const Icon(
                   Icons.shopping_cart_outlined,
                   size: 60,
-                  color: const Color.fromARGB(155, 0, 204, 255),
+                  color: Color.fromARGB(155, 0, 204, 255),
                 ),
                 Text(
                   'wow, aún no has realizado ninguna compra'.capitalize(),
                   textAlign: TextAlign.center,
-                  style: TextStyle(
+                  style: const TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.bold,
                   ),

--- a/lib/src/features/my_purchases/presentation/widgets/my_purchase_tile.dart
+++ b/lib/src/features/my_purchases/presentation/widgets/my_purchase_tile.dart
@@ -96,7 +96,7 @@ class _MyPurchasetileState extends State<MyPurchasetile> {
                 children: <Widget>[
                   Text(
                     widget._purchase.productName.toTitleCase(),
-                    style: TextStyle(
+                    style: const TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.bold,
                     ),
@@ -117,7 +117,7 @@ class _MyPurchasetileState extends State<MyPurchasetile> {
                                 widget._purchase.statusTimeline.last.timestamp
                                     .toDate(),
                               )}',
-                              style: TextStyle(
+                              style: const TextStyle(
                                 color: Colors.grey,
                               ),
                             ),

--- a/lib/src/features/my_purchases/presentation/widgets/my_purchases_body.dart
+++ b/lib/src/features/my_purchases/presentation/widgets/my_purchases_body.dart
@@ -23,7 +23,7 @@ class _MyPurchasesBodyState extends State<MyPurchasesBody> {
   @override
   Widget build(BuildContext context) {
     return widget._purchases.isEmpty
-        ? SliverToBoxAdapter(child: EmptyPurchases())
+        ? const SliverToBoxAdapter(child: EmptyPurchases())
         : _buildList();
   }
 

--- a/lib/src/features/navigationbar/presentation/widgets/destination.dart
+++ b/lib/src/features/navigationbar/presentation/widgets/destination.dart
@@ -37,7 +37,7 @@ class Destination extends StatelessWidget {
     return Badge.count(
       count: 1,
       isLabelVisible: _showBadge,
-      offset: Offset(5, -5),
+      offset: const Offset(5, -5),
       child: HugeIcon(
         icon: _icon,
         color: color,

--- a/lib/src/features/new_location/presentation/new_location.dart
+++ b/lib/src/features/new_location/presentation/new_location.dart
@@ -65,7 +65,7 @@ class _NewLocationState extends State<NewLocation>
         ..add(
           Marker(
             point: position,
-            child: Icon(
+            child: const Icon(
               Icons.location_on_rounded,
               color: Colors.red,
               size: 25,
@@ -144,7 +144,7 @@ class _NewLocationState extends State<NewLocation>
             showCupertinoModalPopup(
               context: context,
               barrierDismissible: false,
-              builder: (BuildContext context) => PopUpLoadingStatus(),
+              builder: (BuildContext context) => const PopUpLoadingStatus(),
             );
           }
           if (state is ErrorSaving) {
@@ -212,7 +212,7 @@ class _NewLocationState extends State<NewLocation>
                           }
                         },
                       ),
-                      SizedBox(
+                      const SizedBox(
                         height: 10,
                       )
                     ],

--- a/lib/src/features/new_location/presentation/widgets/new_location_button.dart
+++ b/lib/src/features/new_location/presentation/widgets/new_location_button.dart
@@ -22,7 +22,7 @@ class NewLocationButton extends StatelessWidget {
             padding: Constants.mainPadding,
             child: Text(
               'guardar ubicacion'.capitalize(),
-              style: TextStyle(
+              style: const TextStyle(
                 color: Colors.white,
                 fontWeight: FontWeight.w800,
               ),

--- a/lib/src/features/new_location/presentation/widgets/new_location_input.dart
+++ b/lib/src/features/new_location/presentation/widgets/new_location_input.dart
@@ -2,7 +2,7 @@ import 'package:extensions/extensions.dart';
 import 'package:flutter/material.dart';
 
 class NewLocationInput extends StatelessWidget {
-  NewLocationInput({
+  const NewLocationInput({
     required this.controller,
     required this.label,
     this.validator,
@@ -15,7 +15,7 @@ class NewLocationInput extends StatelessWidget {
   final String? Function(String? value)? validator;
   final void Function(String value)? onChanged;
 
-  final TextStyle _textStyle = TextStyle(
+  final TextStyle _textStyle = const TextStyle(
     fontWeight: FontWeight.w600,
   );
 

--- a/lib/src/features/new_location/presentation/widgets/new_location_map.dart
+++ b/lib/src/features/new_location/presentation/widgets/new_location_map.dart
@@ -59,8 +59,8 @@ class _NewLocationMapState extends State<NewLocationMap>
               child: FlutterMap(
                 options: MapOptions(
                   initialZoom: 15,
-                  initialCenter: LatLng(4.277866, -73.520570),
-                  interactionOptions: InteractionOptions(
+                  initialCenter: const LatLng(4.277866, -73.520570),
+                  interactionOptions: const InteractionOptions(
                     flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
                   ),
                   onTap: widget.onTap,

--- a/lib/src/features/productDetail/presentation/cubit/product_cubit.dart
+++ b/lib/src/features/productDetail/presentation/cubit/product_cubit.dart
@@ -23,7 +23,7 @@ class ProductDetailCubit extends Cubit<ProductDetailState> {
     required String productId,
   }) async {
     await Future<void>.delayed(
-      Duration(
+      const Duration(
         milliseconds: 300,
       ),
     );
@@ -70,7 +70,7 @@ class ProductDetailCubit extends Cubit<ProductDetailState> {
   Future<void> _addToLastSeen({required String productId}) async {
     try {
       await Future<void>.delayed(
-        Duration(
+        const Duration(
           seconds: 3,
         ),
       );

--- a/lib/src/features/productDetail/presentation/product.dart
+++ b/lib/src/features/productDetail/presentation/product.dart
@@ -54,7 +54,7 @@ class _ProductDetailState extends State<ProductDetail> {
               child: CustomScrollView(
                 controller: _scrollController,
                 physics: state is LoadingProduct
-                    ? NeverScrollableScrollPhysics()
+                    ? const NeverScrollableScrollPhysics()
                     : Constants.bouncingScrollPhysics,
                 shrinkWrap: true,
                 slivers: <Widget>[
@@ -75,7 +75,7 @@ class _ProductDetailState extends State<ProductDetail> {
                         ErrorLoadingProduct _ => Center(
                             child: Text(state.message),
                           ),
-                        _ => LoadingProductShimmer()
+                        _ => const LoadingProductShimmer()
                       },
                     ),
                   ),

--- a/lib/src/features/productDetail/presentation/widgets/loading/loading_product_shimmer.dart
+++ b/lib/src/features/productDetail/presentation/widgets/loading/loading_product_shimmer.dart
@@ -26,18 +26,18 @@ class _LoadingProductShimmerState extends State<LoadingProductShimmer> {
                 Flexible(
                   child: Material(
                     borderRadius: Constants.mainBorderRadius,
-                    child: SizedBox(
+                    child: const SizedBox(
                       width: double.infinity,
                       height: 50,
                     ),
                   ),
                 ),
-                SizedBox(
+                const SizedBox(
                   width: 10,
                 ),
                 Material(
                   borderRadius: Constants.mainBorderRadius,
-                  child: SizedBox(
+                  child: const SizedBox(
                     width: 110,
                     height: 50,
                   ),
@@ -48,7 +48,7 @@ class _LoadingProductShimmerState extends State<LoadingProductShimmer> {
               padding: const EdgeInsets.symmetric(vertical: 10.0),
               child: Material(
                 borderRadius: Constants.mainBorderRadius,
-                child: SizedBox(
+                child: const SizedBox(
                   width: double.infinity,
                   height: 120,
                 ),
@@ -60,7 +60,7 @@ class _LoadingProductShimmerState extends State<LoadingProductShimmer> {
               children: <Widget>[
                 Material(
                   borderRadius: Constants.mainBorderRadius,
-                  child: SizedBox(
+                  child: const SizedBox(
                     width: 110,
                     height: 90,
                   ),
@@ -71,7 +71,7 @@ class _LoadingProductShimmerState extends State<LoadingProductShimmer> {
                 Flexible(
                   child: Material(
                     borderRadius: Constants.mainBorderRadius,
-                    child: SizedBox(
+                    child: const SizedBox(
                       width: double.infinity,
                       height: 90,
                     ),
@@ -96,7 +96,7 @@ class _LoadingProductShimmerState extends State<LoadingProductShimmer> {
                       ),
                       child: Material(
                         borderRadius: Constants.mainBorderRadius,
-                        child: SizedBox(
+                        child: const SizedBox(
                           width: 90,
                           height: 90,
                         ),
@@ -110,7 +110,7 @@ class _LoadingProductShimmerState extends State<LoadingProductShimmer> {
               padding: const EdgeInsets.symmetric(vertical: 10.0),
               child: Material(
                 borderRadius: Constants.mainBorderRadius,
-                child: SizedBox(
+                child: const SizedBox(
                   width: double.infinity,
                   height: 120,
                 ),

--- a/lib/src/features/productDetail/presentation/widgets/productHeader/product_header.dart
+++ b/lib/src/features/productDetail/presentation/widgets/productHeader/product_header.dart
@@ -54,7 +54,7 @@ class ProductHeader extends SliverPersistentHeaderDelegate {
                 child: ClipRRect(
                   child: BackdropFilter(
                     filter: Constants.imageFilterBlur,
-                    child: DecoratedBox(
+                    child: const DecoratedBox(
                       decoration: BoxDecoration(
                         color: Constants.secondaryColor,
                       ),

--- a/lib/src/features/productDetail/presentation/widgets/productHeader/widgets/carrousell_indicator.dart
+++ b/lib/src/features/productDetail/presentation/widgets/productHeader/widgets/carrousell_indicator.dart
@@ -28,7 +28,7 @@ class _CarrousellIndicatorState extends State<CarrousellIndicator> {
               child: ClipRRect(
                 child: BackdropFilter(
                   filter: Constants.imageFilterBlur,
-                  child: DecoratedBox(
+                  child: const DecoratedBox(
                     decoration: BoxDecoration(
                       color: Colors.black45,
                     ),

--- a/lib/src/features/productDetail/presentation/widgets/productHeader/widgets/full_screen_image.dart
+++ b/lib/src/features/productDetail/presentation/widgets/productHeader/widgets/full_screen_image.dart
@@ -64,7 +64,7 @@ class _FullScreenImageState extends State<FullScreenImage> {
           child: ClipRRect(
             child: BackdropFilter(
               filter: Constants.imageFilterBlur,
-              child: DecoratedBox(
+              child: const DecoratedBox(
                 decoration: BoxDecoration(
                   color: Colors.black45,
                 ),

--- a/lib/src/features/productDetail/presentation/widgets/relatedProducts/related_product.dart
+++ b/lib/src/features/productDetail/presentation/widgets/relatedProducts/related_product.dart
@@ -24,7 +24,7 @@ class RelatedProducts extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
-          Text(
+          const Text(
             'Productos relacionados',
             style: TextStyle(
               fontSize: 16,
@@ -81,7 +81,7 @@ class RelatedProducts extends StatelessWidget {
                                   _relatedProduct[index].name.capitalize(),
                                   maxLines: 2,
                                   overflow: TextOverflow.ellipsis,
-                                  style: TextStyle(
+                                  style: const TextStyle(
                                     fontSize: 13,
                                     fontWeight: FontWeight.w800,
                                     height: .9,
@@ -94,7 +94,7 @@ class RelatedProducts extends StatelessWidget {
                                 formatPrice(
                                   _relatedProduct[index].basePrice,
                                 ),
-                                style: TextStyle(
+                                style: const TextStyle(
                                   fontSize: 16,
                                   color: Constants.primaryColor,
                                   fontWeight: FontWeight.w900,

--- a/lib/src/features/productDetail/presentation/widgets/tags/tags.dart
+++ b/lib/src/features/productDetail/presentation/widgets/tags/tags.dart
@@ -31,7 +31,7 @@ class Tags extends StatelessWidget {
                     ),
                     child: Text(
                       '#${tag.capitalize()}',
-                      style: TextStyle(
+                      style: const TextStyle(
                         color: Constants.primaryColor,
                         fontWeight: FontWeight.w600,
                       ),

--- a/lib/src/features/profile/presentation/widgets/account_button.dart
+++ b/lib/src/features/profile/presentation/widgets/account_button.dart
@@ -34,13 +34,13 @@ class AccountButton extends StatelessWidget {
                 Text.rich(
                   TextSpan(
                     text: '$label \n'.capitalize(),
-                    style: TextStyle(
+                    style: const TextStyle(
                       fontWeight: FontWeight.w600,
                     ),
                     children: <InlineSpan>[
                       TextSpan(
                         text: information,
-                        style: TextStyle(
+                        style: const TextStyle(
                           color: Colors.blueGrey,
                         ),
                       ),
@@ -49,7 +49,7 @@ class AccountButton extends StatelessWidget {
                 ),
               ],
             ),
-            Icon(
+            const Icon(
               Icons.arrow_forward_ios_rounded,
               size: 14,
             )

--- a/lib/src/features/profile/presentation/widgets/account_section.dart
+++ b/lib/src/features/profile/presentation/widgets/account_section.dart
@@ -35,7 +35,7 @@ class AccountSection extends StatelessWidget {
                 ),
                 Text(
                   titleSection.capitalize(),
-                  style: TextStyle(
+                  style: const TextStyle(
                     fontSize: 20,
                     fontWeight: FontWeight.bold,
                     color: Constants.primaryColor,

--- a/lib/src/features/profile/presentation/widgets/close_sesion_button.dart
+++ b/lib/src/features/profile/presentation/widgets/close_sesion_button.dart
@@ -29,7 +29,7 @@ class CloseSesion extends StatelessWidget implements AccountButton {
             ),
             Text(
               label.capitalize(),
-              style: TextStyle(
+              style: const TextStyle(
                 color: Colors.redAccent,
                 fontWeight: FontWeight.w700,
               ),

--- a/lib/src/features/pruchase/presentation/purchase.dart
+++ b/lib/src/features/pruchase/presentation/purchase.dart
@@ -47,7 +47,7 @@ class _PurchaseState extends State<Purchase> {
         },
         builder: (BuildContext context, PurchaseState state) {
           return Scaffold(
-            appBar: PruchaseAppBar(),
+            appBar: const PruchaseAppBar(),
             body: Column(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
@@ -59,13 +59,13 @@ class _PurchaseState extends State<Purchase> {
                       ProductInformation(
                         product: state.product,
                       ),
-                      PaymentMethod(),
-                      DeliveryOption(),
-                      DeliveryAddress(),
+                      const PaymentMethod(),
+                      const DeliveryOption(),
+                      const DeliveryAddress(),
                     ],
                   ),
                 ),
-                ConfirmButton()
+                const ConfirmButton()
               ],
             ),
           );

--- a/lib/src/features/pruchase/presentation/widgets/card_tile.dart
+++ b/lib/src/features/pruchase/presentation/widgets/card_tile.dart
@@ -23,7 +23,7 @@ class CartTile extends StatelessWidget {
               groupValue: true,
               onChanged: (bool? value) {},
             ),
-            SizedBox(
+            const SizedBox(
               width: 40,
               height: 40,
               child: ImageLoader(
@@ -36,7 +36,7 @@ class CartTile extends StatelessWidget {
                 padding: Constants.mainPadding,
                 child: Text(
                   _cardNumber,
-                  style: TextStyle(
+                  style: const TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.bold,
                   ),

--- a/lib/src/features/pruchase/presentation/widgets/confirm_button/confrim_button.dart
+++ b/lib/src/features/pruchase/presentation/widgets/confirm_button/confrim_button.dart
@@ -74,7 +74,7 @@ class _ConfirmButtonState extends State<ConfirmButton>
               spacing: Constants.mainPaddingValue / 3,
               children: <Widget>[
                 if (state.product.deliverymethod == Deliverymethod.delivery)
-                  InformationTile(
+                  const InformationTile(
                     label: 'Domicilio',
                     data: deliveryPrice,
                     fontSize: 14,
@@ -128,7 +128,7 @@ class _ConfirmButtonState extends State<ConfirmButton>
                                     ),
                                   PurchaseStatus.initial => Text(
                                       'confirmar compra'.toTitleCase(),
-                                      style: TextStyle(
+                                      style: const TextStyle(
                                         color: Colors.white,
                                         fontWeight: FontWeight.w600,
                                         fontSize: 16,

--- a/lib/src/features/pruchase/presentation/widgets/delivery_address.dart
+++ b/lib/src/features/pruchase/presentation/widgets/delivery_address.dart
@@ -71,7 +71,7 @@ class _DeliveryAddressState extends State<DeliveryAddress>
           onChanged: (String value) {
             context
                 .read<PurchaseCubit>()
-                .setAddress(address: GeoPoint(0, 0), description: value);
+                .setAddress(address: const GeoPoint(0, 0), description: value);
           },
           cursorOpacityAnimates: true,
           decoration: InputDecoration(

--- a/lib/src/features/pruchase/presentation/widgets/delivery_option.dart
+++ b/lib/src/features/pruchase/presentation/widgets/delivery_option.dart
@@ -19,7 +19,7 @@ class _DeliveryOptionState extends State<DeliveryOption> {
       title: 'Método de entrega',
       child: Column(
         spacing: Constants.mainPaddingValue,
-        children: <Widget>[
+        children: const <Widget>[
           _DeliveryOption(
             index: 0,
             title: 'Envio a domicilio',
@@ -90,7 +90,7 @@ class __DeliveryOptionState extends State<_DeliveryOption> {
                 Text.rich(
                   TextSpan(
                     text: widget.title,
-                    style: TextStyle(
+                    style: const TextStyle(
                       fontWeight: FontWeight.w600,
                       fontSize: 16,
                     ),
@@ -99,7 +99,7 @@ class __DeliveryOptionState extends State<_DeliveryOption> {
                         text: widget.index == 0
                             ? ' (${formatPrice(4000)})'
                             : ' (Gratis)',
-                        style: TextStyle(
+                        style: const TextStyle(
                           color: Constants.primaryColor,
                           fontSize: 14,
                         ),
@@ -107,7 +107,7 @@ class __DeliveryOptionState extends State<_DeliveryOption> {
                     ],
                   ),
                 ),
-                Spacer(),
+                const Spacer(),
                 Icon(
                   widget.icon,
                   color: Constants.primaryColor,

--- a/lib/src/features/pruchase/presentation/widgets/payment_method.dart
+++ b/lib/src/features/pruchase/presentation/widgets/payment_method.dart
@@ -30,7 +30,7 @@ class _PaymentMethodState extends State<PaymentMethod> {
           spacing: Constants.mainPaddingValue,
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
+          children: const <Widget>[
             CartTile(
               cardNumber: '**** **** **** 1234',
             ),

--- a/lib/src/features/pruchase/presentation/widgets/product_information.dart
+++ b/lib/src/features/pruchase/presentation/widgets/product_information.dart
@@ -69,13 +69,13 @@ class ProductInformation extends StatelessWidget {
     return Text.rich(
       TextSpan(
         text: '$label: '.capitalize(),
-        style: TextStyle(
+        style: const TextStyle(
           fontWeight: FontWeight.bold,
         ),
         children: <InlineSpan>[
           TextSpan(
             text: data.toTitleCase(),
-            style: TextStyle(
+            style: const TextStyle(
               fontWeight: FontWeight.w100,
             ),
           ),

--- a/lib/src/features/pruchase/presentation/widgets/purchase_header.dart
+++ b/lib/src/features/pruchase/presentation/widgets/purchase_header.dart
@@ -30,13 +30,13 @@ class PruchaseAppBar extends StatelessWidget implements PreferredSizeWidget {
                       flex: 5,
                       child: Text(
                         'Facturación'.capitalize(),
-                        style: TextStyle(
+                        style: const TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.bold,
                         ),
                       ),
                     ),
-                    Spacer(
+                    const Spacer(
                       flex: 1,
                     )
                   ],

--- a/lib/src/features/pruchase/presentation/widgets/title_section.dart
+++ b/lib/src/features/pruchase/presentation/widgets/title_section.dart
@@ -12,7 +12,7 @@ class TitleSection extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(
       _label.capitalize(),
-      style: TextStyle(
+      style: const TextStyle(
         fontSize: 18,
         fontWeight: FontWeight.w700,
       ),

--- a/lib/src/features/purchase_detail/presentation/purchase_detail.dart
+++ b/lib/src/features/purchase_detail/presentation/purchase_detail.dart
@@ -61,7 +61,7 @@ class _PurchaseDetailState extends State<PurchaseDetail>
                 ),
                 SliverPadding(
                   padding: Constants.mainPadding,
-                  sliver: ProductData(),
+                  sliver: const ProductData(),
                 ),
                 if (state is Success)
                   SliverPadding(

--- a/lib/src/features/purchase_detail/presentation/widgets/purchase_detail_header.dart
+++ b/lib/src/features/purchase_detail/presentation/widgets/purchase_detail_header.dart
@@ -27,7 +27,7 @@ class PurchaseDetailAppbar extends SliverPersistentHeaderDelegate {
                   sigmaX: 20 * percent,
                   sigmaY: 20 * percent,
                 ),
-                child: Material(
+                child: const Material(
                   color: Colors.transparent,
                 ),
               ),

--- a/lib/src/features/purchase_detail/presentation/widgets/purchase_detail_tail.dart
+++ b/lib/src/features/purchase_detail/presentation/widgets/purchase_detail_tail.dart
@@ -25,7 +25,7 @@ class PurchaseStatusTile extends StatelessWidget {
         children: <Widget>[
           Text(
             state.status.name,
-            style: TextStyle(
+            style: const TextStyle(
               fontSize: 16,
               fontWeight: FontWeight.bold,
               color: Constants.primaryColor,
@@ -33,7 +33,7 @@ class PurchaseStatusTile extends StatelessWidget {
           ),
           Text(
             'Updated: ${DateFormat('dd/MM/yyyy HH:mm').format(state.timestamp.toDate())}',
-            style: TextStyle(
+            style: const TextStyle(
               fontSize: 12,
               color: Colors.grey,
             ),

--- a/lib/src/features/purchase_detail/presentation/widgets/purchase_product_data.dart
+++ b/lib/src/features/purchase_detail/presentation/widgets/purchase_product_data.dart
@@ -19,7 +19,7 @@ class ProductData extends StatelessWidget {
           padding: Constants.mainPadding / 4,
           child: Row(
             spacing: Constants.mainPaddingValue,
-            children: <Widget>[
+            children: const <Widget>[
               SizedBox(
                 width: 60,
                 height: 60,

--- a/lib/src/features/search/presentation/cubit/search_cubit.dart
+++ b/lib/src/features/search/presentation/cubit/search_cubit.dart
@@ -10,7 +10,7 @@ part 'search_state.dart';
 class SearchCubit extends Cubit<SearchState> {
   SearchCubit({required SearchUsecase usecase})
       : _usecase = usecase,
-        super(SearchInitial());
+        super(const SearchInitial());
   final SearchUsecase _usecase;
 
   Timer? _debounceTimer;
@@ -20,10 +20,10 @@ class SearchCubit extends Cubit<SearchState> {
     _debounceTimer?.cancel();
     emit(Loading());
     _debounceTimer = Timer(
-      Duration(milliseconds: 500),
+      const Duration(milliseconds: 500),
       () async {
         if (query.isEmpty) {
-          emit(SearchInitial());
+          emit(const SearchInitial());
         } else {
           try {
             final List<String> ngrams = generateNgrams(query, 3);

--- a/lib/src/features/search/presentation/search.dart
+++ b/lib/src/features/search/presentation/search.dart
@@ -45,7 +45,7 @@ class _SearchPageState extends State<SearchPage> {
                 pinned: true,
               ),
               if (state is Loading)
-                SliverFillRemaining(
+                const SliverFillRemaining(
                   child: Center(
                     child: CircularProgressIndicator(),
                   ),
@@ -116,7 +116,7 @@ class _SearchStringResultsState extends State<SearchStringResults> {
                             ? 'no se encontraron coincidencias'
                             : 'no tienes historial de busqueda')
                         .capitalize(),
-                    style: TextStyle(
+                    style: const TextStyle(
                       fontWeight: FontWeight.w700,
                       fontSize: 16,
                       color: Constants.secondaryColor,
@@ -149,7 +149,7 @@ class _SearchStringResultsState extends State<SearchStringResults> {
                 child: Row(
                   spacing: Constants.mainPaddingValue,
                   children: <Widget>[
-                    Icon(Icons.search_rounded),
+                    const Icon(Icons.search_rounded),
                     Text.rich(
                       TextSpan(
                         children: highlightOccurrences(

--- a/lib/src/features/search/presentation/widgets/search_header.dart
+++ b/lib/src/features/search/presentation/widgets/search_header.dart
@@ -41,12 +41,12 @@ class SearchHeader extends SliverPersistentHeaderDelegate {
                             context.read<SearchCubit>().search(
                                   query: value,
                                 ),
-                        style: TextStyle(
+                        style: const TextStyle(
                           color: Constants.primaryColor,
                         ),
                         decoration: InputDecoration(
                           hintText: 'Buscar productos',
-                          hintStyle: TextStyle(
+                          hintStyle: const TextStyle(
                             color: Constants.primaryColor,
                           ),
                           prefixIcon: const Icon(Icons.search_rounded),
@@ -54,7 +54,7 @@ class SearchHeader extends SliverPersistentHeaderDelegate {
                           border: OutlineInputBorder(
                             borderRadius: Constants.mainBorderRadius,
                             gapPadding: Constants.mainPaddingValue * 2,
-                            borderSide: BorderSide(
+                            borderSide: const BorderSide(
                               width: 0,
                               style: BorderStyle.none,
                             ),

--- a/lib/src/features/set_default_location/presentation/cubit/set_default_location_cubit.dart
+++ b/lib/src/features/set_default_location/presentation/cubit/set_default_location_cubit.dart
@@ -8,7 +8,7 @@ class SetDefaultLocationCubit extends Cubit<SetDefaultLocationState> {
   SetDefaultLocationCubit({
     required SetDefaultLocationUsecase usecase,
   })  : _usecase = usecase,
-        super(SetDefaultLocationState());
+        super(const SetDefaultLocationState());
   final SetDefaultLocationUsecase _usecase;
 
   void setDefaultLocation({required String locationId}) async {

--- a/lib/src/features/set_default_location/presentation/set_default_location.dart
+++ b/lib/src/features/set_default_location/presentation/set_default_location.dart
@@ -36,7 +36,7 @@ class _SetDefaultLocationState extends State<SetDefaultLocation> {
             child: switch (state) {
               Loading _ => Padding(
                   padding: Constants.mainPadding / 2,
-                  child: SizedBox(
+                  child: const SizedBox(
                     width: 30,
                     height: 30,
                     child: CircularProgressIndicator.adaptive(),

--- a/lib/src/features/settings/presentation/settings.dart
+++ b/lib/src/features/settings/presentation/settings.dart
@@ -24,7 +24,7 @@ class _SettingsState extends State<Settings> {
             pinned: true,
           ),
           SliverList.list(
-            children: <Widget>[
+            children: const <Widget>[
               SettingTile(
                 sectionTitle: 'idioma',
                 child: LanguageButton(),

--- a/lib/src/features/theme_mode_selector/presentation/theme_mode_selector.dart
+++ b/lib/src/features/theme_mode_selector/presentation/theme_mode_selector.dart
@@ -32,12 +32,12 @@ class _ThemeModeSelectorState extends State<ThemeModeSelector> {
                 height: 24,
                 child: ClipRRect(
                   borderRadius: Constants.mainBorderRadius,
-                  child: VerticalDivider(
+                  child: const VerticalDivider(
                     width: 2,
                   ),
                 ),
               ),
-              children: <Widget>[
+              children: const <Widget>[
                 ThemeModeTile(
                   themeMode: ThemeMode.system,
                   icon: HugeIcons.strokeRoundedSmartPhone01,

--- a/lib/src/features/user_menu/user_menu.dart
+++ b/lib/src/features/user_menu/user_menu.dart
@@ -18,7 +18,7 @@ class _UserMenuState extends State<UserMenu> {
       child: ListView(
         physics: Constants.bouncingScrollPhysics,
         padding: Constants.mainPadding,
-        children: <Widget>[
+        children: const <Widget>[
           UserPhoto(),
           UserCredits(),
           MenuOptions(),

--- a/lib/src/features/user_menu/widgets/menu_options.dart
+++ b/lib/src/features/user_menu/widgets/menu_options.dart
@@ -11,7 +11,7 @@ class MenuOptions extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: Constants.paddingTop,
-      child: Column(
+      child: const Column(
         children: <_OptionTile>[
           _OptionTile(
             icon: HugeIcons.strokeRoundedNotification03,
@@ -72,7 +72,7 @@ class _OptionTile extends StatelessWidget {
             Icon(icon),
             Text(
               label.capitalize(),
-              style: TextStyle(
+              style: const TextStyle(
                 fontWeight: FontWeight.w600,
                 fontSize: 16,
               ),

--- a/lib/src/features/user_menu/widgets/user_credits.dart
+++ b/lib/src/features/user_menu/widgets/user_credits.dart
@@ -26,14 +26,15 @@ class UserCredits extends StatelessWidget {
                     children: <InlineSpan>[
                       TextSpan(
                         text: formatPrice(_credits),
-                        style: TextStyle(
+                        style: const TextStyle(
                           color: Constants.secondaryColor,
                           fontFamily: 'AlbertSans',
                         ),
                       )
                     ],
                   ),
-                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.w800),
+                  style: const TextStyle(
+                      fontSize: 16, fontWeight: FontWeight.w800),
                 ),
               ],
             ),

--- a/lib/src/features/widgets/header_buton.dart
+++ b/lib/src/features/widgets/header_buton.dart
@@ -67,7 +67,7 @@ class HeaderButton extends StatelessWidget {
               padding: Constants.buttonPadding,
               child: Badge(
                 backgroundColor: Colors.black,
-                label: Text(
+                label: const Text(
                   '1',
                   style: TextStyle(
                     fontSize: 9,

--- a/lib/src/features/widgets/image_loader.dart
+++ b/lib/src/features/widgets/image_loader.dart
@@ -28,10 +28,11 @@ class _ImageLoaderState extends State<ImageLoader>
         String url,
         DownloadProgress progress,
       ) =>
-          Center(
-        child: const CircularProgressIndicator.adaptive(),
+          const Center(
+        child: CircularProgressIndicator.adaptive(),
       ),
-      errorWidget: (BuildContext context, String url, Object error) => Center(
+      errorWidget: (BuildContext context, String url, Object error) =>
+          const Center(
         child: SizedBox(
           width: 50,
           height: 50,

--- a/lib/src/features/widgets/loading_status.dart
+++ b/lib/src/features/widgets/loading_status.dart
@@ -13,7 +13,7 @@ class LoadingStatus extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
-          CircularProgressIndicator.adaptive(),
+          const CircularProgressIndicator.adaptive(),
           Text(
             'loading...'.capitalize(),
             style: const TextStyle(

--- a/lib/src/features/widgets/pop_up_loading_status.dart
+++ b/lib/src/features/widgets/pop_up_loading_status.dart
@@ -11,7 +11,7 @@ class PopUpLoadingStatus extends StatelessWidget {
         borderRadius: Constants.mainBorderRadius,
         child: Padding(
           padding: Constants.mainPadding,
-          child: CircularProgressIndicator(),
+          child: const CircularProgressIndicator(),
         ),
       ),
     );

--- a/lib/src/features/widgets/text_area.dart
+++ b/lib/src/features/widgets/text_area.dart
@@ -58,7 +58,7 @@ class _TextAreaState extends State<TextArea> {
         textAlign: TextAlign.start,
         decoration: InputDecoration(
           labelText: widget._label?.capitalize(),
-          labelStyle: TextStyle(
+          labelStyle: const TextStyle(
             fontWeight: FontWeight.w600,
           ),
           alignLabelWithHint: true,
@@ -66,7 +66,7 @@ class _TextAreaState extends State<TextArea> {
         inputFormatters: <TextInputFormatter>[
           CapitalizeAfterDotFormatter(),
         ],
-        style: TextStyle(
+        style: const TextStyle(
           fontFamily: 'Questrial',
           fontWeight: FontWeight.w700,
         ),


### PR DESCRIPTION
 performance

- Updated various stateless widgets to use `const` constructors for better performance and reduced rebuilds.
- Modified instances of `Text`, `Icon`, `SizedBox`, `SliverFillRemaining`, and other widgets to use `const` where applicable.
- Ensured consistent use of `const` in widget trees across multiple files, including `my_locations`, `my_purchases`, `productDetail`, `search`, and `pruchase` features.
- Enhanced readability and maintainability of the codebase by applying these changes uniformly.